### PR TITLE
Fix gisdev.io attribution link

### DIFF
--- a/webapp/src/configuration.json
+++ b/webapp/src/configuration.json
@@ -6,5 +6,5 @@
     "municipalities": "limits_IT_municipalities.json",
     "provinces": "limits_IT_provinces.json",
     "regions": "limits_IT_regions.json",
-     "mapAttribution": "Wikimedia Maps. Map data &copy; <a href='http://osm.org/copyright'>OpenStreetMap</a> contributors. Realizzato da <a href='https: //gisdev.io'>GISdevio&nbsp; <img style='margin-bottom:-2px' height='12' src='https://gisdev.io/img/logo_short.png'></a>"
+     "mapAttribution": "Wikimedia Maps. Map data &copy; <a href='http://osm.org/copyright'>OpenStreetMap</a> contributors. Realizzato da <a href='https://gisdev.io'>GISdevio&nbsp; <img style='margin-bottom:-2px' height='12' src='https://gisdev.io/img/logo_short.png'></a>"
 }


### PR DESCRIPTION
Fix #17 