### PR TITLE
Replace /usr/bin/imposm with imposm

### DIFF
--- a/backend/imposm/run_import_boundaries.sh
+++ b/backend/imposm/run_import_boundaries.sh
@@ -15,9 +15,9 @@ cat <<EOF > $(pwd)/config/estratti.json
 EOF
 
 
-/usr/bin/imposm import -config $(pwd)/config/estratti.json --read $WORK_DIR/input/pbf/italy-latest.osm.pbf -overwritecache
-/usr/bin/imposm import -config $(pwd)/config/estratti.json -write -optimize
-/usr/bin/imposm import -config $(pwd)/config/estratti.json -deployproduction
+imposm import -config $(pwd)/config/estratti.json --read $WORK_DIR/input/pbf/italy-latest.osm.pbf -overwritecache
+imposm import -config $(pwd)/config/estratti.json -write -optimize
+imposm import -config $(pwd)/config/estratti.json -deployproduction
 
 
 


### PR DESCRIPTION
Assumere che `imposm` sia in `/usr/bin` è problematico, perché può essere anche altrove, anzi, solitamente è così, dato che non è uno strumento presente nei repository ufficiali di Debian e i programmi di terze parti vengono installati altrove solitamente. `/usr/bin` è già presente in `$PATH` solitamente, quindi non c'è motivo di usare il percorso assoluto.